### PR TITLE
Symbolic links creation, needed for deb package

### DIFF
--- a/startinnova
+++ b/startinnova
@@ -34,5 +34,12 @@ fi
 export XDG_MENU_PREFIX="innova-"
 export XDG_CURRENT_DESKTOP="Innova"
 
+#Current code, require symbolic links at home folder, and this cant be packaged
+[ -f $HOME/Launcher_Mini.gambas ]   && echo "symbolic link Launcher_Mini already exists"   || ln -s /usr/bin/qlauncher $HOME/Launcher_Mini.gambas
+[ -f $HOME/Launcher_CNB.gambas ]    && echo "symbolic link Launcher_CNB  already exists"   || ln -s /usr/bin/qlauncher $HOME/Launcher_CNB.gambas
+[ -f $HOME/Launcher_Tablet.gambas ] && echo "symbolic link Launcher_Tablet already exists" || ln -s /usr/bin/qlauncher $HOME/Launcher_Tablet.gambas
+[ -f $HOME/QSettings.gambas ] && echo "symbolic link QSettings already exists" || ln -s /usr/bin/qsettings $HOME/QSettings.gambas
+
+
 # Start the Innova session
 exec /usr/bin/Innova.gambas


### PR DESCRIPTION
El proyecto QLauncher busca los ejecutables: QSettings.gambas, Launcher_Mini.gambas, Launcher_Tablet.gambas, Launcher_CBN.gambas, los cuales no existen pues todos los ejecutables se instalan en /usr/bin/* para esto es necesario crear links.
Los links no pueden incluirse en el paquete por estar en el folder $HOME.
Para esto se agrega la creacion en el archivo startinnova, se crearan unicamente si no existen.
Si estos links no existen no abre el Launcher.